### PR TITLE
fix: prevent user update request being called twice

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -255,26 +255,11 @@ const completeTask = async (task) => {
     completedTask.earlyBonus = xpResult.earlyBonus;
     completedTask.overduePenalty = xpResult.overduePenalty;
 
+    // Batch state update to be updated in a single render
     setTasks(updatedTasks);
     setCompletedTasks(updatedCompletedTasks);
 
-    if (userId) {
-      // For authenticated users, only update server
-      await fetch(`${API_BASE_URL}/users/${userId}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          xp: getTotalXP(),
-          level: level,
-          tasksCompleted: updatedCompletedTasks.length,
-          tasks: updatedTasks,
-          completedTasks: updatedCompletedTasks
-        }),
-      });
-    } else {
+    if(!userId) {
       // For unauthenticated users, use localStorage
       localStorage.setItem('tasks', JSON.stringify(updatedTasks));
       localStorage.setItem('completedtasks', JSON.stringify(updatedCompletedTasks));


### PR DESCRIPTION
## fix: prevent user update request being called twice

#### problem 
-  user request was being called twice 
    - on line 150 useEffect is triggered when tasks and completedTasks states are updated
    - on line 261 inside the completeTask function 
         - xp was calculated, but the state update hasn't been processed yet for getTotalXP, so old value was being returned
         - caused the xp data to stay unchanged if this request reaches the server after the request in useEffect

#### solution
- let useEffect handle the server updates after the state has been updated
- removed the user request on line 261
- react 18 does batch state updates automatically so a promise all was not needed for the set states